### PR TITLE
feat: add the expand_stall_threshold parameter

### DIFF
--- a/assets/hb/modules/announcement-bar/js/index.ts
+++ b/assets/hb/modules/announcement-bar/js/index.ts
@@ -2,9 +2,14 @@ import * as params from '@params'
 
 (() => {
   let timer = 0
+  let expandTimeout = 0
 
   const clearTimer = (): void => {
     clearInterval(timer)
+  }
+
+  const clearExpandTimeout = (): void => {
+    clearTimeout(expandTimeout)
   }
 
   document.addEventListener('DOMContentLoaded', () => {
@@ -27,14 +32,24 @@ import * as params from '@params'
       }, params.announcement_bar.interval ?? 5000)
     }
 
+    const expanding = (): void => {
+      clearExpandTimeout()
+      expandTimeout = setTimeout(() => {
+        bar.classList.add('active')
+      }, params.announcement_bar.expand_stall_threshold ?? 500)
+    }
+
     setTimer()
 
     const bar = document.querySelector('.hb-announcement-bar') as HTMLElement
     bar.addEventListener('mouseover', () => {
       clearTimer()
+      expanding()
     })
     bar.addEventListener('mouseout', () => {
       setTimer()
+      clearExpandTimeout()
+      bar.classList.remove('active')
     })
   })
 })()

--- a/assets/hb/modules/announcement-bar/scss/index.scss
+++ b/assets/hb/modules/announcement-bar/scss/index.scss
@@ -30,7 +30,7 @@
         color: var(--#{$prefix}navbar-active-color);
     }
 
-    &:hover {
+    &.active {
         max-height: 30vh;
         overflow: auto!important;
         padding-top: var(--#{$prefix}navbar-padding-y);

--- a/hugo.toml
+++ b/hugo.toml
@@ -9,6 +9,7 @@ path = "github.com/hbstack/header"
 
 [params.hb.announcement_bar]
 interval = 5000
+expand_stall_threshold = 500
 
 [params.hugopress.modules.hb-announcement-bar.hooks.hb-header-nav-before]
 cacheable = true


### PR DESCRIPTION
How many milliseconds must elapse before considering the expansion (show all announcements) experience stalled.